### PR TITLE
Upgrade rust analyzer to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,16 +55,15 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -94,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -104,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "anymap"
@@ -208,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata",
  "serde",
 ]
 
@@ -250,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.72.2"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171aca76a3199e771ea0b94ec260984ed9cba62af8e478142974dbaa594d583b"
+checksum = "77a6fe1f5394d14b81d2f3f605832a3ce35ed0bf120bc7ef437ce27fd4929c6a"
 dependencies = [
  "anyhow",
  "base64",
@@ -280,10 +279,8 @@ dependencies = [
  "ignore",
  "im-rc",
  "indexmap 1.9.3",
- "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "jobserver",
- "lazy_static",
  "lazycell",
  "libc",
  "libgit2-sys",
@@ -293,6 +290,7 @@ dependencies = [
  "os_info",
  "pasetors",
  "pathdiff",
+ "pulldown-cmark",
  "rand",
  "rustfix",
  "semver",
@@ -303,6 +301,7 @@ dependencies = [
  "sha1",
  "shell-escape",
  "strip-ansi-escapes",
+ "syn 2.0.29",
  "tar",
  "tempfile",
  "termcolor",
@@ -322,7 +321,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
 dependencies = [
- "petgraph 0.6.3",
+ "petgraph 0.6.4",
  "semver",
  "serde",
  "toml",
@@ -347,7 +346,7 @@ dependencies = [
  "cargo",
  "cargo-lock",
  "cargo_toml",
- "chalk-ir",
+ "chalk-ir 0.93.0",
  "clap",
  "codespan-reporting",
  "colored",
@@ -355,9 +354,9 @@ dependencies = [
  "env_logger",
  "flate2",
  "inquire",
- "itertools",
+ "itertools 0.11.0",
  "log",
- "petgraph 0.6.3",
+ "petgraph 0.6.4",
  "proc-macro2",
  "quote",
  "ra_ap_hir",
@@ -376,7 +375,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "syn 2.0.27",
+ "syn 2.0.29",
  "tar",
  "toml",
  "walkdir",
@@ -384,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e2320a2b1242f9181a3347ae0884bb497e1853d299da99780fa1e96f9abe23"
+checksum = "dd54c8b94a0c851d687924460637361c355afafa72d973fe8644499fbdee8fae"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -401,7 +400,7 @@ dependencies = [
  "shell-escape",
  "tempfile",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -445,35 +444,58 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chalk-derive"
-version = "0.88.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df80a3fbc1f0e59f560eeeebca94bf655566a8ad3023c210a109deb6056455a"
+checksum = "ff5053a8a42dbff5279a82423946fc56dc1253b76cf211b2b3c14b3aad4e1281"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
+ "synstructure",
+]
+
+[[package]]
+name = "chalk-derive"
+version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264726159011fc7f22c23eb51f49021ece6e71bc358b96e7f2e842db0b14162b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
  "synstructure",
 ]
 
 [[package]]
 name = "chalk-ir"
-version = "0.88.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39e5272016916956298cceea5147006f897972c274a768ed4d6e074efe5d3fb"
+checksum = "8a56de2146a8ed0fcd54f4bd50db852f1de4eac9e1efe568494f106c21b77d2a"
 dependencies = [
  "bitflags 1.3.2",
- "chalk-derive",
+ "chalk-derive 0.92.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "chalk-ir"
+version = "0.93.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65c17407d4c756b8f7f84344acb0fb96364d0298822743219bb25769b6d00df"
+dependencies = [
+ "bitflags 1.3.2",
+ "chalk-derive 0.93.0",
  "lazy_static",
 ]
 
 [[package]]
 name = "chalk-recursive"
-version = "0.88.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d60b42ad7478d3e027e2f9ea4e99fbbb8fdee0c8c3cf068be269f57e603618"
+checksum = "5cc09e6e9531f3544989ef89b189e80fbc7ad9e2f73f1c5e03ddc9ffb0527463"
 dependencies = [
- "chalk-derive",
- "chalk-ir",
+ "chalk-derive 0.92.0",
+ "chalk-ir 0.92.0",
  "chalk-solve",
  "rustc-hash",
  "tracing",
@@ -481,15 +503,15 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.88.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30620ea5b36819525eaab2204f4b8e1842fc7ee36826424a28bef59ae7fecf"
+checksum = "b392e02b4c81ec76d3748da839fc70a5539b83d27c9030668463d34d5110b860"
 dependencies = [
- "chalk-derive",
- "chalk-ir",
+ "chalk-derive 0.92.0",
+ "chalk-ir 0.92.0",
  "ena",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.10.5",
  "petgraph 0.5.1",
  "rustc-hash",
  "tracing",
@@ -510,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "7c8d502cbaec4595d2e7d5f61e318f05417bd2b66fdc3809498f0d3fdf0bea27"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -521,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "5891c7bc0edb3e1c2204fc5e94009affabeb1821c9e5fdc3959536c5c0bb984d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -534,14 +556,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -812,7 +834,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -823,7 +845,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -836,7 +858,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
@@ -1027,14 +1049,14 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "filetime"
-version = "0.2.21"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys 0.48.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1051,9 +1073,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -1153,12 +1175,13 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.44.1"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf41b61f7df395284f7a579c0fa1a7e012c5aede655174d4e91299ef1cac643"
+checksum = "bf2a03ec66ee24d1b2bae3ab718f8d14f141613810cb7ff6756f7db667f1cd82"
 dependencies = [
  "gix-actor",
  "gix-attributes",
+ "gix-commitgraph",
  "gix-config",
  "gix-credentials",
  "gix-date",
@@ -1173,6 +1196,7 @@ dependencies = [
  "gix-index",
  "gix-lock",
  "gix-mailmap",
+ "gix-negotiate",
  "gix-object",
  "gix-odb",
  "gix-pack",
@@ -1201,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848efa0f1210cea8638f95691c82a46f98a74b9e3524f01d4955ebc25a8f84f3"
+checksum = "9fe73f9f6be1afbf1bd5be919a9636fa560e2f14d42262a934423ed6760cd838"
 dependencies = [
  "bstr",
  "btoi",
@@ -1215,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3015baa01ad2122fbcaab7863c857a603eb7b7ec12ac8141207c42c6439805e2"
+checksum = "78b79590ac382f80d87e06416f5fcac6fee5d83dcb152a00ed0bdbaa988acc31"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1258,10 +1282,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-config"
-version = "0.22.0"
+name = "gix-commitgraph"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d252a0eddb6df74600d3d8872dc9fe98835a7da43110411d705b682f49d4ac1"
+checksum = "e8490ae1b3d55c47e6a71d247c082304a2f79f8d0332c1a2f5693d42a2021a09"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f310120ae1ba8f0ca52fb22876ce9bad5b15c8ffb3eb7302e4b64a3b9f681c"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -1294,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4874a4fc11ffa844a3c2b87a66957bda30a73b577ef1acf15ac34df5745de5ff"
+checksum = "c6f89fea8acd28f5ef8fa5042146f1637afd4d834bc8f13439d8fd1e5aca0d65"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1322,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644a0f2768bc42d7a69289ada80c9e15c589caefc6a315d2307202df83ed1186"
+checksum = "9029ad0083cc286a4bd2f5b3bf66bb66398abc26f2731a2824cd5edfc41a0e33"
 dependencies = [
  "gix-hash",
  "gix-object",
@@ -1334,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6b61363e63e7cdaa3e6f96acb0257ebdb3d8883e21eba5930c99f07f0a5fc0"
+checksum = "aba9c6c0d1f2b2efe65581de73de4305004612d49c83773e783202a7ef204f46"
 dependencies = [
  "bstr",
  "dunce",
@@ -1349,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf69b0f5c701cc3ae22d3204b671907668f6437ca88862d355eaf9bc47a4f897"
+checksum = "3a8c493409bf6060d408eec9bbdd1b12ea351266b50012e2a522f75dfc7b8314"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1369,18 +1407,18 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b37a1832f691fdc09910bd267f9a2e413737c1f9ec68c6e31f9e802616278a9"
+checksum = "30da8997008adb87f94e15beb7ee229f8a48e97af585a584bfee4a5a1880aab5"
 dependencies = [
  "gix-features",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07c98204529ac3f24b34754540a852593d2a4c7349008df389240266627a72a"
+checksum = "cd0ade1e80ab1f079703d1824e1daf73009096386aa7fd2f0477f6e4ac0a558e"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1411,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba205b6df563e2906768bb22834c82eb46c5fdfcd86ba2c347270bc8309a05b2"
+checksum = "fc6f7f101a0ccce808dbf7008ba131dede94e20257e7bde7a44cbb2f8c775625"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1423,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39c1ccc8f1912cbbd5191efc28dbc5f0d0598042aa56bc09427b7c34efab3ba"
+checksum = "616ba958fabfb11263fa042c35690d48a6c7be4e9277e2c7e24ff263b3fe7b82"
 dependencies = [
  "bitflags 2.3.3",
  "bstr",
@@ -1445,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c693d7f05730fa74a7c467150adc7cea393518410c65f0672f80226b8111555"
+checksum = "3ec5d5e6f07316d3553aa7425e3ecd935ec29882556021fe1696297a448af8d2"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -1456,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8856cec3bdc3610c06970d28b6cb20a0c6621621cf9a8ec48cbd23f2630f362"
+checksum = "4653701922c920e009f1bc4309feaff14882ade017770788f9a150928da3fa6a"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1466,10 +1504,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-object"
-version = "0.29.2"
+name = "gix-negotiate"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d96bd620fd08accdd37f70b2183cfa0b001b4f1c6ade8b7f6e15cb3d9e261ce"
+checksum = "945c3ef1e912e44a5f405fc9e924edf42000566a1b257ed52cb1293300f6f08c"
+dependencies = [
+ "bitflags 2.3.3",
+ "gix-commitgraph",
+ "gix-hash",
+ "gix-object",
+ "gix-revision",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8926c8f51c44dec3e709cb5dbc93deb9e8d4064c43c9efc54c158dcdfe8446c7"
 dependencies = [
  "bstr",
  "btoi",
@@ -1486,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2f324aa67672b6d0f2c0fa93f96eb6a7029d260e4c1df5dce3c015f5e5add"
+checksum = "4b234d806278eeac2f907c8b5a105c4ba537230c1a9d9236d822bf0db291f8f3"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -1504,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164a515900a83257ae4aa80e741655bee7a2e39113fb535d7a5ac623b445ff20"
+checksum = "7d2a14cb3156037eedb17d6cb7209b7180522b8949b21fd0fe3184c0a1d0af88"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -1563,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.32.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e49417f1730f4dbc2f7d9a2ab0f8b2f49ef08f97270691403ecde3d961e3a"
+checksum = "92a17058b45c461f0847528c5fb6ee6e76115e026979eb2d2202f98ee94f6c24"
 dependencies = [
  "bstr",
  "btoi",
@@ -1591,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e03989e9d49954368e1b526578230fc7189d1634acdfbe79e9ba1de717e15d5"
+checksum = "ebdd999256f4ce8a5eefa89999879c159c263f3493a951d62aa5ce42c0397e1c"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -1611,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6ea733820df67e4cd7797deb12727905824d8f5b7c59d943c456d314475892"
+checksum = "72bfd622abc86dd8ad1ec51b9eb77b4f1a766b94e3a1b87cf4a022c5b5570cf4"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -1625,15 +1678,30 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.13.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810f35e9afeccca999d5d348b239f9c162353127d2e13ff3240e31b919e35476"
+checksum = "5044f56cd7a487ce9b034cbe0252ae0b6b47ff56ca3dabd79bc30214d0932cd7"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
+ "gix-revwalk",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2623ba8747914f151f5e12b65adac576ab459dbed5f50a36c7a3e9cbf2d3ca"
+dependencies = [
+ "gix-commitgraph",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
  "thiserror",
 ]
 
@@ -1651,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "5.0.3"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71a0d32f34e71e86586124225caefd78dabc605d0486de580d717653addf182"
+checksum = "b3785cb010e9dc5c446dfbf02bc1119fc17d3a48a27c029efcb3a3c32953eb10"
 dependencies = [
  "gix-fs",
  "libc",
@@ -1672,9 +1740,9 @@ checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
 
 [[package]]
 name = "gix-transport"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c2bf7b989c679695ef635fc7d9e80072e08101be4b53193c8e8b649900102"
+checksum = "64a39ffed9a9078ed700605e064b15d7c6ae50aa65e7faa36ca6919e8081df15"
 dependencies = [
  "base64",
  "bstr",
@@ -1691,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5be1e807f288c33bb005075111886cceb43ed8a167b3182a0f62c186e2a0dd1"
+checksum = "b0842e984cb4bf26339dc559f3a1b8bf8cdb83547799b2b096822a59f87f33d9"
 dependencies = [
  "gix-hash",
  "gix-hashtable",
@@ -1703,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc77f89054297cc81491e31f1bab4027e554b5ef742a44bd7035db9a0f78b76"
+checksum = "f1663df25ac42047a2547618d2a6979a26f478073f6306997429235d2cd4c863"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1736,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69eaff0ae973a9d37c40f02ae5ae50fa726c8fc2fd3ab79d0a19eb61975aafa"
+checksum = "d388ad962e8854402734a7387af8790f6bdbc8d05349052dab16ca4a0def50f6"
 dependencies = [
  "bstr",
  "filetime",
@@ -1986,6 +2054,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -2075,6 +2144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "la-arena"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3752f229dcc5a481d60f385fa479ff46818033d881d2d801aa27dffcfb5e8306"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,16 +2247,6 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
 ]
 
 [[package]]
@@ -2212,6 +2286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-index"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee59ea2e50e61bae4f09eee6416820f2ba9796d6e924c86f6e4f699dcb1a7ac"
+dependencies = [
+ "nohash-hasher",
+ "text-size",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,30 +2319,33 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lsp-server"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b52dccdf3302eefab8c8a1273047f0a3c3dca4b527c8458d00c09484c8371928"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "lsp-types"
-version = "0.93.2"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
  "serde_json",
  "serde_repr",
  "url",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2322,14 +2409,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2363,6 +2450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -2387,7 +2480,7 @@ dependencies = [
  "libc",
  "mio",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2430,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]
@@ -2544,7 +2637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
@@ -2563,15 +2656,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2618,9 +2711,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "perf-event"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d6393d9238342159080d79b78cb59c67399a8e7ecfa5d410bd614169e4e823"
+checksum = "5396562cd2eaa828445d6d34258ae21ee1eb9d40fe626ca7f51c8dccb4af9d66"
 dependencies = [
  "libc",
  "perf-event-open-sys",
@@ -2628,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "perf-event-open-sys"
-version = "4.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c44fb1c7651a45a3652c4afc6e754e40b3d6e6556f1487e2b230bfc4f33c2a8"
+checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
 dependencies = [
  "libc",
 ]
@@ -2647,12 +2740,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -2691,7 +2784,7 @@ checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools",
+ "itertools 0.10.5",
  "predicates-core",
 ]
 
@@ -2731,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "23.1.2"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9516b775656bc3e8985e19cd4b8c0c0de045095074e453d2c0a513b5f978392d"
+checksum = "1d67eb4220992a4a052a4bb03cf776e493ecb1a3a36bab551804153d63486af7"
 dependencies = [
  "parking_lot 0.12.1",
 ]
@@ -2780,19 +2873,30 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "ra_ap_base_db"
-version = "0.0.149"
+name = "ra-ap-rustc_lexer"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749b321b0215468617f0d4be48cb4bda45b05bb6795b88c30617dbb7f2d0dbe6"
+checksum = "e1c145702ed3f237918e512685185dc8a4d0edc3a5326c63d20361d8ba9b45b3"
 dependencies = [
+ "unic-emoji-char",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ra_ap_base_db"
+version = "0.0.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d71fc8c713ffb677304e7d0b4489607df1aed30e20d96a95cee7a3415aa8e9"
+dependencies = [
+ "la-arena",
  "ra_ap_cfg",
  "ra_ap_profile",
  "ra_ap_stdx",
@@ -2802,13 +2906,14 @@ dependencies = [
  "ra_ap_vfs",
  "rustc-hash",
  "salsa",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_cfg"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3138e8f1ab3fa4ec60f7d318d7ef085f8a174fcfbe4c818b59785b84bf86e93"
+checksum = "9c81a0fc52925057a5d48e3167a9797e373bbf9d13129232d0e4a812b997ffb4"
 dependencies = [
  "ra_ap_tt",
  "rustc-hash",
@@ -2816,14 +2921,13 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_flycheck"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8f963030238dea49ea9952b110b471eb7f8120faec2eeb08dd4106434df4c3"
+checksum = "4ba72d6b6a82f57b32c69e7b168f8bc5c346c4bcc02a02c28d30ed2965338536"
 dependencies = [
  "cargo_metadata",
  "command-group",
  "crossbeam-channel",
- "jod-thread",
  "ra_ap_paths",
  "ra_ap_stdx",
  "ra_ap_toolchain",
@@ -2835,13 +2939,13 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_hir"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb5deba96cfbe6aaf201adaf517a8c33612992e3c73a7392210e4f2e33d8fe7"
+checksum = "0a0e40dc2a4a9127cf92f3310c469e05fdda1bedc74031921bf75edae60b112f"
 dependencies = [
  "arrayvec 0.7.4",
  "either",
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "ra_ap_base_db",
  "ra_ap_cfg",
@@ -2854,17 +2958,18 @@ dependencies = [
  "ra_ap_tt",
  "rustc-hash",
  "smallvec",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_hir_def"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf83641e085c8d038e8c68338b74dd69233d48fc82ff552dfb68bef2194d37f"
+checksum = "401d8e3bab39fa97f5032a9963d714fd629212d0f0bcd7775a2dc5bd816d86e2"
 dependencies = [
  "anymap",
  "arrayvec 0.7.4",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cov-mark",
  "dashmap",
  "drop_bomb",
@@ -2873,14 +2978,14 @@ dependencies = [
  "hashbrown 0.12.3",
  "hkalbasi-rustc-ap-rustc_abi",
  "hkalbasi-rustc-ap-rustc_index",
- "indexmap 1.9.3",
- "itertools",
+ "indexmap 2.0.0",
+ "itertools 0.10.5",
+ "la-arena",
  "once_cell",
  "ra_ap_base_db",
  "ra_ap_cfg",
  "ra_ap_hir_expand",
  "ra_ap_intern",
- "ra_ap_la-arena",
  "ra_ap_limit",
  "ra_ap_mbe",
  "ra_ap_profile",
@@ -2890,22 +2995,23 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "tracing",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_hir_expand"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715af793bb64b9771e82a797ceb7aa89ed32c523638cebbc5e538b69106fea7d"
+checksum = "955c889265bfae6e8bf43b2aac42532d301ae750406d5e6e71b7af194c314f51"
 dependencies = [
  "cov-mark",
  "either",
  "hashbrown 0.12.3",
- "itertools",
+ "itertools 0.10.5",
+ "la-arena",
  "ra_ap_base_db",
  "ra_ap_cfg",
  "ra_ap_intern",
- "ra_ap_la-arena",
  "ra_ap_limit",
  "ra_ap_mbe",
  "ra_ap_profile",
@@ -2915,30 +3021,34 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "tracing",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_hir_ty"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd778cfcfbd35b39c682143050db4448668d377a18fae64f3cae377dd0ae01bc"
+checksum = "3e5d036114b01abd934e181d840e92033eb027a85b48797387418888789fbc11"
 dependencies = [
  "arrayvec 0.7.4",
- "bitflags 1.3.2",
- "chalk-derive",
- "chalk-ir",
+ "bitflags 2.3.3",
+ "chalk-derive 0.92.0",
+ "chalk-ir 0.92.0",
  "chalk-recursive",
  "chalk-solve",
  "cov-mark",
+ "either",
  "ena",
  "hkalbasi-rustc-ap-rustc_index",
- "itertools",
+ "itertools 0.10.5",
+ "la-arena",
+ "nohash-hasher",
  "once_cell",
+ "oorandom",
  "ra_ap_base_db",
  "ra_ap_hir_def",
  "ra_ap_hir_expand",
  "ra_ap_intern",
- "ra_ap_la-arena",
  "ra_ap_limit",
  "ra_ap_profile",
  "ra_ap_stdx",
@@ -2947,20 +3057,22 @@ dependencies = [
  "scoped-tls",
  "smallvec",
  "tracing",
+ "triomphe",
  "typed-arena",
 ]
 
 [[package]]
 name = "ra_ap_ide"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4392239e8d0f5ecd0c96994370d353b46257692e23f3e15598612c5a9d2a9294"
+checksum = "484d5fa98c7c7c9662fb2da3144cfd7190372a34bc5fd0adc690087010202e0e"
 dependencies = [
  "cov-mark",
  "crossbeam-channel",
  "dot",
  "either",
- "itertools",
+ "itertools 0.10.5",
+ "nohash-hasher",
  "oorandom",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
@@ -2978,18 +3090,19 @@ dependencies = [
  "ra_ap_toolchain",
  "smallvec",
  "tracing",
+ "triomphe",
  "url",
 ]
 
 [[package]]
 name = "ra_ap_ide_assists"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd28e7538b7cfe283d700876da1d3d0e78904868a6cb273e8c2a3b770939521"
+checksum = "6e4dfb1a7bb94aa78ae7f3a4ccdaffbd90ae54b484c4547e9de3999c661b9698"
 dependencies = [
  "cov-mark",
  "either",
- "itertools",
+ "itertools 0.10.5",
  "ra_ap_hir",
  "ra_ap_ide_db",
  "ra_ap_profile",
@@ -3001,12 +3114,12 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_ide_completion"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009b78e07d390f8687b6ac6868ab44ed82b2efdcc553781f060769ae7ab55b25"
+checksum = "71aad9862967fe779d6b26b142d279304e59618383100974bf908281e128401f"
 dependencies = [
  "cov-mark",
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "ra_ap_base_db",
  "ra_ap_hir",
@@ -3020,17 +3133,19 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_ide_db"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed6ce36a85b52ef486a86ca060e5c00277ea78168182cb58d511b17411ead83"
+checksum = "af0e19eb6754bebe251905f77a2b0144cca9d3f7b6759c57bd496877e5a51fa7"
 dependencies = [
  "arrayvec 0.7.4",
  "cov-mark",
  "either",
  "fst",
- "indexmap 1.9.3",
- "itertools",
+ "indexmap 2.0.0",
+ "itertools 0.10.5",
+ "line-index",
  "memchr",
+ "nohash-hasher",
  "once_cell",
  "ra_ap_base_db",
  "ra_ap_hir",
@@ -3043,17 +3158,19 @@ dependencies = [
  "rayon",
  "rustc-hash",
  "tracing",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_ide_diagnostics"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f99e3854ea93cba0527b1a88aa5a4194e7c06eccd725189f354bb338acdfe00"
+checksum = "f0a157186d1db3540235eb94278635681b1b602afc63c2dc3ea295ad2b224338"
 dependencies = [
  "cov-mark",
  "either",
- "itertools",
+ "itertools 0.10.5",
+ "once_cell",
  "ra_ap_cfg",
  "ra_ap_hir",
  "ra_ap_ide_db",
@@ -3066,61 +3183,65 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_ide_ssr"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18bf9241d42b79626b6bdbe21a33befd68ac3cc311c7e674e7cecde34f0da13"
+checksum = "fc12c024791e4808fc4ea21c70bd44a245a2091dbf894f3c23e4b98e4af3ebbf"
 dependencies = [
  "cov-mark",
- "itertools",
+ "itertools 0.10.5",
+ "nohash-hasher",
  "ra_ap_hir",
  "ra_ap_ide_db",
  "ra_ap_parser",
  "ra_ap_stdx",
  "ra_ap_syntax",
  "ra_ap_text_edit",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_intern"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b76a994e672adabefa4cebbb1e8f8994c20c17f628fd2574f944a132f1e4d0"
+checksum = "a7af132576f23b2b93c14e3aa41548130c2ded2fc10011f787824d7adc77b1ec"
 dependencies = [
  "dashmap",
  "hashbrown 0.12.3",
  "once_cell",
  "rustc-hash",
+ "triomphe",
 ]
 
 [[package]]
-name = "ra_ap_la-arena"
-version = "0.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4a0c80c6019507c485ee321058ffcc9f975a17192a7575a363d2f2e235a832"
-
-[[package]]
 name = "ra_ap_limit"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e78afcbf32928cd9c4e80a3ca9a5d3fbfd4a6a3199b8e3db07cad94862d463"
+checksum = "214222a3ae5d1e947ea7e97d0c162016ce9e5ea815c732e63d6ff373d5a617e4"
 
 [[package]]
-name = "ra_ap_lsp-server"
-version = "0.0.149"
+name = "ra_ap_load-cargo"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93690f990b4e39d9eb717538ea5149e85bd8d401c0538205f5fc51925e254b50"
+checksum = "005c425ab3c16db80747edd4f26464e532002a1a40877f039364ada7d6e23356"
 dependencies = [
+ "anyhow",
  "crossbeam-channel",
- "log",
- "serde",
- "serde_json",
+ "itertools 0.10.5",
+ "ra_ap_ide",
+ "ra_ap_ide_db",
+ "ra_ap_proc_macro_api",
+ "ra_ap_project_model",
+ "ra_ap_tt",
+ "ra_ap_vfs",
+ "ra_ap_vfs-notify",
+ "tracing",
 ]
 
 [[package]]
 name = "ra_ap_mbe"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b35646d9d2836957edcd171d9f28ff1b9cc0203e20bc69531acf41bb063b49"
+checksum = "0147f11aa3f2b48b781ba74162708bac77bc293ec74443b1c4a5395f7a0a7a83"
 dependencies = [
  "cov-mark",
  "ra_ap_parser",
@@ -3134,26 +3255,26 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fca12584b7d616b9a64af2d4cf103757f255e9e98354f347fbe23b1db13868"
+checksum = "342ee20844cf3411c48ae52aa69eedaf11bd99fd4b0361d3070a4267f900f5d6"
 dependencies = [
  "drop_bomb",
+ "ra-ap-rustc_lexer",
  "ra_ap_limit",
- "rustc-ap-rustc_lexer",
 ]
 
 [[package]]
 name = "ra_ap_paths"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d780b450680460bd7ea3e2483dcf15a3ac0ce0ec028696caa342c577d65e5506"
+checksum = "882f7e15bcf2bcfa84b86bc5bd67abe263c39285160282d82989607fc46ad13c"
 
 [[package]]
 name = "ra_ap_proc_macro_api"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997804df7ccc907ae76f6a8ec284592ddb55efc8e23c012ca2fe0d81d647d925"
+checksum = "39347a580d44f6e4e3487d2bb43250561dc3950789b49351243a3933ccfae04c"
 dependencies = [
  "memmap2",
  "object",
@@ -3165,49 +3286,36 @@ dependencies = [
  "serde_json",
  "snap",
  "tracing",
-]
-
-[[package]]
-name = "ra_ap_proc_macro_srv"
-version = "0.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4da04e0d58b1a8756a3e2e901a982347ca21a8cd0ebdf83a898c1d8ab61186f"
-dependencies = [
- "libloading",
- "memmap2",
- "object",
- "ra_ap_mbe",
- "ra_ap_paths",
- "ra_ap_proc_macro_api",
- "ra_ap_tt",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_profile"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400f2df7f3da4439a58981ee223395beed88a86c7dc93a989a36b4a860c36cc"
+checksum = "a65b2498cba0361254503ad7608526918e4667512357927f28447846f6f679d1"
 dependencies = [
  "cfg-if",
  "countme",
+ "la-arena",
  "libc",
  "once_cell",
  "perf-event",
- "ra_ap_la-arena",
  "winapi",
 ]
 
 [[package]]
 name = "ra_ap_project_model"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5468f2f6cfb4bc6bc1c5507b6bc251905a515c05b089785914d057503167cf3"
+checksum = "3b9c931b495cde600a7a5826e28eddcedb72075cae601efc9addb563a8936731"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "itertools 0.10.5",
+ "la-arena",
  "ra_ap_base_db",
  "ra_ap_cfg",
- "ra_ap_la-arena",
  "ra_ap_paths",
  "ra_ap_profile",
  "ra_ap_stdx",
@@ -3217,23 +3325,29 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_rust-analyzer"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72f12c0849f15dc21d05c9e4c00a39136c0cefc396b974b2525f199bbec25d7"
+checksum = "8d9e2cd5adc973134ad5cc9324fc186d25fa840e43647f4ed9c9020eab32e0ab"
 dependencies = [
  "always-assert",
  "anyhow",
  "crossbeam-channel",
  "dissimilar",
- "itertools",
+ "filetime",
+ "itertools 0.10.5",
+ "lsp-server",
  "lsp-types",
+ "mio",
+ "nohash-hasher",
  "num_cpus",
  "oorandom",
  "parking_lot 0.12.1",
+ "parking_lot_core 0.9.6",
  "ra_ap_cfg",
  "ra_ap_flycheck",
  "ra_ap_hir",
@@ -3242,15 +3356,13 @@ dependencies = [
  "ra_ap_ide",
  "ra_ap_ide_db",
  "ra_ap_ide_ssr",
- "ra_ap_lsp-server",
+ "ra_ap_load-cargo",
  "ra_ap_proc_macro_api",
- "ra_ap_proc_macro_srv",
  "ra_ap_profile",
  "ra_ap_project_model",
  "ra_ap_stdx",
  "ra_ap_syntax",
  "ra_ap_toolchain",
- "ra_ap_tt",
  "ra_ap_vfs",
  "ra_ap_vfs-notify",
  "rayon",
@@ -3258,22 +3370,24 @@ dependencies = [
  "scip",
  "serde",
  "serde_json",
- "threadpool",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
  "tracing-tree",
+ "triomphe",
  "winapi",
  "xflags",
 ]
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d776542bf771f4fdf40c21ced864bf213924d8a60d580c970715818471ebd74c"
+checksum = "15ae533cd9946ffe3c27e303126c597e963641725bcd93232b646d781e7b5668"
 dependencies = [
  "always-assert",
+ "crossbeam-channel",
+ "jod-thread",
  "libc",
  "miow",
  "winapi",
@@ -3281,29 +3395,31 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a20b080e1f71cde39e7dd986e56c9dea52be5639875ecf713f60412f337a41"
+checksum = "da79a0cccdf3d9c09ed06462d6e641ff680614a880e0b305193ff4deb4210047"
 dependencies = [
  "cov-mark",
- "indexmap 1.9.3",
- "itertools",
+ "either",
+ "indexmap 2.0.0",
+ "itertools 0.10.5",
  "once_cell",
+ "ra-ap-rustc_lexer",
  "ra_ap_parser",
  "ra_ap_profile",
  "ra_ap_stdx",
  "ra_ap_text_edit",
  "rowan",
- "rustc-ap-rustc_lexer",
  "rustc-hash",
  "smol_str",
+ "triomphe",
 ]
 
 [[package]]
 name = "ra_ap_test_utils"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f418160da780b9ed778af27aca37632cdafcdc2b9a33efbb964c33b72f6fe0ee"
+checksum = "9421ef9cead7f05d621976df1559046d179f7a2ff01ad25b41906dc0602f5910"
 dependencies = [
  "dissimilar",
  "ra_ap_profile",
@@ -3314,28 +3430,28 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_text_edit"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18158c7690e2d0b9d7d1e708db9838628063ce7c7c6e5abe3cae4df30da4721"
+checksum = "9d22e21f9d5d63f1ad4a9715d0bafbb7d3a0acecc5fb9f1821f9d557c3028bf0"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "text-size",
 ]
 
 [[package]]
 name = "ra_ap_toolchain"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b9b9c66352b3c4cf36c88cb1d8083305cd7194baa4dce7c5b5fb0ddd2b1e39"
+checksum = "ea28a9969087461651eab9ab1edf3c48a705e1261fcdd868ef912c114da6b4e6"
 dependencies = [
  "home",
 ]
 
 [[package]]
 name = "ra_ap_tt"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2178f2c74ed554007a684998b5e6e2a24a8cd878b4e1e58a791bd6f0a36bd3e9"
+checksum = "03fc0ca501ebf2c0b27b4a2dc544a3cec3df15fab652ea12098605e9103affa3"
 dependencies = [
  "ra_ap_stdx",
  "smol_str",
@@ -3343,12 +3459,13 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_vfs"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cd60adecd0947e1dd41a3077713381aa0cdcba6dc8777300d7d5b83b9fbe84"
+checksum = "f6b343805de8c0856ef23f6d04cf2694331c942b2310945625c5983ee04ab5c2"
 dependencies = [
  "fst",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "nohash-hasher",
  "ra_ap_paths",
  "ra_ap_stdx",
  "rustc-hash",
@@ -3356,14 +3473,14 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_vfs-notify"
-version = "0.0.149"
+version = "0.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a680f2dbd796844ebeaa2a4d01ae209f412ddc2981f6512ab8bc9b471156e6cd"
+checksum = "4a5ce2f790162ff3e3b89f804cd6a59896cef0a22a97f7c89c4bb751c4efeeb6"
 dependencies = [
  "crossbeam-channel",
- "jod-thread",
  "notify",
  "ra_ap_paths",
+ "ra_ap_stdx",
  "ra_ap_vfs",
  "tracing",
  "walkdir",
@@ -3456,17 +3573,8 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
- "regex-syntax 0.7.4",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3477,14 +3585,8 @@ checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3513,15 +3615,6 @@ dependencies = [
  "memoffset 0.8.0",
  "rustc-hash",
  "text-size",
-]
-
-[[package]]
-name = "rustc-ap-rustc_lexer"
-version = "725.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950742ef8a203aa7661aad3ab880438ddeb7f95d4b837c30d65db1a2c5df68e"
-dependencies = [
- "unicode-xid",
 ]
 
 [[package]]
@@ -3668,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.175"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -3687,13 +3780,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.175"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3707,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -3725,7 +3818,7 @@ checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3739,14 +3832,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -3755,14 +3849,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3cee93715c2e266b9338b7544da68a9f24e227722ba482bd1c024367c77c65"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3866,9 +3960,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smol_str"
-version = "0.1.24"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
 dependencies = [
  "serde",
 ]
@@ -3939,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3950,21 +4044,21 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.29",
  "unicode-xid",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96d2ffad078296368d46ff1cb309be1c23c513b4ab0e22a45de0185275ac96"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -4032,7 +4126,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4043,15 +4137,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]
@@ -4152,7 +4237,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4182,12 +4267,8 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
- "matchers",
- "once_cell",
- "regex",
  "sharded-slab",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -4206,6 +4287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,6 +4303,47 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-emoji-char"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
 
 [[package]]
 name = "unicase"
@@ -4374,7 +4502,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -4396,7 +4524,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4444,7 +4572,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4464,35 +4592,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4605,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "ra_ap_hir_ty",
  "ra_ap_ide",
  "ra_ap_ide_db",
+ "ra_ap_load-cargo",
  "ra_ap_paths",
  "ra_ap_project_model",
  "ra_ap_rust-analyzer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ dependencies = [
  "cargo",
  "cargo-lock",
  "cargo_toml",
- "chalk-ir 0.93.0",
  "clap",
  "codespan-reporting",
  "colored",
@@ -368,7 +367,6 @@ dependencies = [
  "ra_ap_load-cargo",
  "ra_ap_paths",
  "ra_ap_project_model",
- "ra_ap_rust-analyzer",
  "ra_ap_syntax",
  "ra_ap_vfs",
  "semver",
@@ -456,36 +454,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "chalk-derive"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264726159011fc7f22c23eb51f49021ece6e71bc358b96e7f2e842db0b14162b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
- "synstructure",
-]
-
-[[package]]
 name = "chalk-ir"
 version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56de2146a8ed0fcd54f4bd50db852f1de4eac9e1efe568494f106c21b77d2a"
 dependencies = [
  "bitflags 1.3.2",
- "chalk-derive 0.92.0",
- "lazy_static",
-]
-
-[[package]]
-name = "chalk-ir"
-version = "0.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65c17407d4c756b8f7f84344acb0fb96364d0298822743219bb25769b6d00df"
-dependencies = [
- "bitflags 1.3.2",
- "chalk-derive 0.93.0",
+ "chalk-derive",
  "lazy_static",
 ]
 
@@ -495,8 +470,8 @@ version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc09e6e9531f3544989ef89b189e80fbc7ad9e2f73f1c5e03ddc9ffb0527463"
 dependencies = [
- "chalk-derive 0.92.0",
- "chalk-ir 0.92.0",
+ "chalk-derive",
+ "chalk-ir",
  "chalk-solve",
  "rustc-hash",
  "tracing",
@@ -508,8 +483,8 @@ version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b392e02b4c81ec76d3748da839fc70a5539b83d27c9030668463d34d5110b860"
 dependencies = [
- "chalk-derive 0.92.0",
- "chalk-ir 0.92.0",
+ "chalk-derive",
+ "chalk-ir",
  "ena",
  "indexmap 1.9.3",
  "itertools 0.10.5",
@@ -604,16 +579,6 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "command-group"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5080df6b0f0ecb76cab30808f00d937ba725cebe266a3da8cd89dff92f2a9916"
-dependencies = [
- "nix",
- "winapi",
 ]
 
 [[package]]
@@ -2325,31 +2290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "lsp-server"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52dccdf3302eefab8c8a1273047f0a3c3dca4b527c8458d00c09484c8371928"
-dependencies = [
- "crossbeam-channel",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "lsp-types"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
-
-[[package]]
 name = "maybe-async"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,18 +2379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "static_assertions",
-]
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,16 +2410,6 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
 ]
 
 [[package]]
@@ -2601,12 +2519,6 @@ dependencies = [
  "serde",
  "winapi",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p384"
@@ -2833,26 +2745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee4a7d8b91800c8f167a6268d1a1026607368e1adc84e98fe044aeb905302f7"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca157fe12fc7ee2e315f2f735e27df41b3d97cdd70ea112824dac1ffb08ee1c"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
 name = "pulldown-cmark"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,24 +2810,6 @@ checksum = "9c81a0fc52925057a5d48e3167a9797e373bbf9d13129232d0e4a812b997ffb4"
 dependencies = [
  "ra_ap_tt",
  "rustc-hash",
-]
-
-[[package]]
-name = "ra_ap_flycheck"
-version = "0.0.171"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba72d6b6a82f57b32c69e7b168f8bc5c346c4bcc02a02c28d30ed2965338536"
-dependencies = [
- "cargo_metadata",
- "command-group",
- "crossbeam-channel",
- "ra_ap_paths",
- "ra_ap_stdx",
- "ra_ap_toolchain",
- "rustc-hash",
- "serde",
- "serde_json",
- "tracing",
 ]
 
 [[package]]
@@ -3033,8 +2907,8 @@ checksum = "3e5d036114b01abd934e181d840e92033eb027a85b48797387418888789fbc11"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.3.3",
- "chalk-derive 0.92.0",
- "chalk-ir 0.92.0",
+ "chalk-derive",
+ "chalk-ir",
  "chalk-recursive",
  "chalk-solve",
  "cov-mark",
@@ -3327,57 +3201,6 @@ dependencies = [
  "serde_json",
  "tracing",
  "triomphe",
-]
-
-[[package]]
-name = "ra_ap_rust-analyzer"
-version = "0.0.171"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9e2cd5adc973134ad5cc9324fc186d25fa840e43647f4ed9c9020eab32e0ab"
-dependencies = [
- "always-assert",
- "anyhow",
- "crossbeam-channel",
- "dissimilar",
- "filetime",
- "itertools 0.10.5",
- "lsp-server",
- "lsp-types",
- "mio",
- "nohash-hasher",
- "num_cpus",
- "oorandom",
- "parking_lot 0.12.1",
- "parking_lot_core 0.9.6",
- "ra_ap_cfg",
- "ra_ap_flycheck",
- "ra_ap_hir",
- "ra_ap_hir_def",
- "ra_ap_hir_ty",
- "ra_ap_ide",
- "ra_ap_ide_db",
- "ra_ap_ide_ssr",
- "ra_ap_load-cargo",
- "ra_ap_proc_macro_api",
- "ra_ap_profile",
- "ra_ap_project_model",
- "ra_ap_stdx",
- "ra_ap_syntax",
- "ra_ap_toolchain",
- "ra_ap_vfs",
- "ra_ap_vfs-notify",
- "rayon",
- "rustc-hash",
- "scip",
- "serde",
- "serde_json",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
- "tracing-tree",
- "triomphe",
- "winapi",
- "xflags",
 ]
 
 [[package]]
@@ -3717,15 +3540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scip"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bfbb10286f69fad7c78db71004b7839bf957788359fe0c479f029f9849136b"
-dependencies = [
- "protobuf",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,21 +3619,9 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
- "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
 ]
 
 [[package]]
@@ -3886,15 +3688,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -4248,43 +4041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
-name = "tracing-tree"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d6b63348fad3ae0439b8bebf8d38fb5bda0b115d7a8a7e6f165f12790c58c3"
-dependencies = [
- "is-terminal",
- "nu-ansi-term",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -4409,7 +4165,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -4417,12 +4172,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -4716,21 +4465,6 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "xflags"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4554b580522d0ca238369c16b8f6ce34524d61dafe7244993754bbd05f2c2ea"
-dependencies = [
- "xflags-macros",
-]
-
-[[package]]
-name = "xflags-macros"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e7b3ca8977093aae6b87b6a7730216fc4c53a6530bab5c43a783cd810c1a8"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,41 +19,41 @@ incremental = false
 codegen-units = 16
 
 [dependencies]
-anyhow = "1.0.71"
-clap = { version = "4.2.7", features = ["derive"] }
+anyhow = "1.0.75"
+clap = { version = "4.4.1", features = ["derive"] }
 codespan-reporting = "0.11.1"
-colored = "2.0.0"
+colored = "2.0.4"
 env_logger = "0.10.0"
-inquire = "0.6.1"
-log = "0.4.17"
-petgraph = "0.6.3"
-proc-macro2 = { version = "1.0.56", features = ["span-locations"] }
-quote = "1.0.27"
-ra_ap_hir = "0.0.149"
-ra_ap_hir_ty = "0.0.149"
-chalk-ir = "0.88.0"
-ra_ap_ide = "0.0.149"
-ra_ap_ide_db = "0.0.149"
-ra_ap_paths = "0.0.149"
-ra_ap_project_model = "0.0.149"
-ra_ap_rust-analyzer = "0.0.149"
-ra_ap_syntax = "0.0.149"
-ra_ap_vfs = "0.0.149"
-serde = { version = "1.0.162", features = ["derive"] }
-serde_json = "1.0.96"
-serde_with = "3.0.0"
-sha2 = "0.10.6"
+inquire = "0.6.2"
+log = "0.4.20"
+petgraph = "0.6.4"
+proc-macro2 = { version = "1.0.66", features = ["span-locations"] }
+quote = "1.0.33"
+ra_ap_hir = "0.0.171"
+ra_ap_hir_ty = "0.0.171"
+chalk-ir = "0.93.0"
+ra_ap_ide = "0.0.171"
+ra_ap_ide_db = "0.0.171"
+ra_ap_paths = "0.0.171"
+ra_ap_project_model = "0.0.171"
+ra_ap_rust-analyzer = "0.0.171"
+ra_ap_syntax = "0.0.171"
+ra_ap_vfs = "0.0.171"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.105"
+serde_with = "3.3.0"
+sha2 = "0.10.7"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-toml = "0.7.3"
+toml = "0.7.6"
 walkdir = "2.3.3"
-itertools = {version = "0.10.5"}
-ra_ap_hir_expand = "0.0.149"
-ra_ap_hir_def = "0.0.149"
+itertools = {version = "0.11.0"}
+ra_ap_hir_expand = "0.0.171"
+ra_ap_hir_def = "0.0.171"
 cargo-lock = { version = "9.0.0", features = ["dependency-tree"] }
 curl = "0.4.44"
-flate2 = "1.0.26"
-tar = "0.4.38"
-cargo = "0.72.2"
-cargo_toml = "0.15.2"
+flate2 = "1.0.27"
+tar = "0.4.40"
+cargo = "0.73.1"
+cargo_toml = "0.15.3"
 semver = "1.0.18"
 assert_cmd = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ walkdir = "2.3.3"
 itertools = {version = "0.11.0"}
 ra_ap_hir_expand = "0.0.171"
 ra_ap_hir_def = "0.0.171"
+ra_ap_load-cargo = "0.0.171"
 cargo-lock = { version = "9.0.0", features = ["dependency-tree"] }
 curl = "0.4.44"
 flate2 = "1.0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,41 +20,39 @@ codegen-units = 16
 
 [dependencies]
 anyhow = "1.0.75"
+assert_cmd = "2.0.12"
+cargo = "0.73.1"
+cargo_toml = "0.15.3"
+cargo-lock = { version = "9.0.0", features = ["dependency-tree"] }
 clap = { version = "4.4.1", features = ["derive"] }
 codespan-reporting = "0.11.1"
 colored = "2.0.4"
+curl = "0.4.44"
 env_logger = "0.10.0"
+flate2 = "1.0.27"
 inquire = "0.6.2"
+itertools = {version = "0.11.0"}
 log = "0.4.20"
 petgraph = "0.6.4"
 proc-macro2 = { version = "1.0.66", features = ["span-locations"] }
 quote = "1.0.33"
 ra_ap_hir = "0.0.171"
+ra_ap_hir_def = "0.0.171"
+ra_ap_hir_expand = "0.0.171"
 ra_ap_hir_ty = "0.0.171"
-chalk-ir = "0.93.0"
 ra_ap_ide = "0.0.171"
 ra_ap_ide_db = "0.0.171"
+ra_ap_load-cargo = "0.0.171"
 ra_ap_paths = "0.0.171"
 ra_ap_project_model = "0.0.171"
-ra_ap_rust-analyzer = "0.0.171"
 ra_ap_syntax = "0.0.171"
 ra_ap_vfs = "0.0.171"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_with = "3.3.0"
+semver = "1.0.18"
 sha2 = "0.10.7"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
+tar = "0.4.40"
 toml = "0.7.6"
 walkdir = "2.3.3"
-itertools = {version = "0.11.0"}
-ra_ap_hir_expand = "0.0.171"
-ra_ap_hir_def = "0.0.171"
-ra_ap_load-cargo = "0.0.171"
-cargo-lock = { version = "9.0.0", features = ["dependency-tree"] }
-curl = "0.4.44"
-flate2 = "1.0.27"
-tar = "0.4.40"
-cargo = "0.73.1"
-cargo_toml = "0.15.3"
-semver = "1.0.18"
-assert_cmd = "2.0.12"


### PR DESCRIPTION
Basically I ran  `cargo upgrade --incompatible` and then fixed all the errors and API changes in rust-analyzer -- so we should now be up-to-date with upstream.

## File changes

I will just merge this, but @lzoghbi @DavidThien may be worth glancing over the diff (of this pull request) just to see what changed and if I messed anything up! The important changes are in `name_resolution.rs`.

## Regressions

`make test` is passing with no regressions! I had to guess at some of the API changes, but it seems to be working. The only thing is we are getting a few new warnings for CanonicalType invariants failing, will fix later. I also didn't try `make top10` yet.
