### PR TITLE
pinned to version rustc-1.85.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -2440,9 +2440,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libdbus-sys"
@@ -4631,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4642,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4664,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Cargo Scan is a tool for auditing Rust crates.
 ## Quick-start
 
 1. Clone this repository.
-2. Run `rustup update` to ensure you have the latest version of Rust (or install it via the [official website]((https://www.rust-lang.org/tools/install))).
-3. Run `cargo build`.
+2. Run `cargo build`.
 
 Once built, either:
 
-4. Follow the instructions to install the VSCode extension below; or
-5. If you prefer to use Cargo Scan as a basic CLI tool or want to incorporate it in other projects, see "using the CLI tool" below.
+3. Follow the instructions to install the VSCode extension below; or
+4. If you prefer to use Cargo Scan as a basic CLI tool or want to incorporate it in other projects, see "using the CLI tool" below.
 
 ## Using the VSCode Extension
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.85.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
I added `rust-toolchain.toml` to pin to `rustc-1.85.0`

Without this, running `rustup update` updates toolchain to `rustc 1.89.0` as of August 16,2025. 

Running `cargo build` after that fails to compile `cargo-scan` because one of the dependency `ra_ap_stdx-0.0.185` performs a cast which is no longer supported. I am also quoting the compiler error message below:

```
[PATH]/index.crates.io-1949cf8c6b5b557f/ra_ap_stdx-0.0.185/src/anymap.rs:283:40
    |
283 |                 unsafe { Box::from_raw(raw as *mut $t) }
    |                                        ^^^^^^^^^^^^^^ unsupported cast
...
378 | impl_clone!(dyn CloneAny + Send);
    | -------------------------------- in this macro invocation
    |
    = note: this could allow UB elsewhere
    = help: use `transmute` if you're sure this is sound
    = note: this error originates in the macro `impl_clone` (in Nightly builds, run with -Z macro-backtrace for more info)
```

with `rust-toolchain-toml` added the compilation succeeds with this warning :

```
warning: the following packages contain code that will be rejected by a future version of Rust: ra_ap_stdx v0.0.185
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

I have also removed `2. Run `rustup update` to ensure you have the latest version of Rust (or install it via the [official website]((https://www.rust-lang.org/tools/install))).` from `README.md` because a working version has been pinned. 